### PR TITLE
Transformer

### DIFF
--- a/src/pybeech/__init__.py
+++ b/src/pybeech/__init__.py
@@ -3,4 +3,5 @@ __all__ = [
     "lexer",
     "parser",
     "beech_types",
+    "transformer"
 ]

--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -1,7 +1,10 @@
 """Main script for pybeech package."""
+from typing import Union
 
+from src.pybeech.beech_types import Symbol
 from src.pybeech.lexer import Lexer
 from src.pybeech.parser import Parser
+from src.pybeech.transformer import transformer
 
 source = r"""
 hello {
@@ -22,10 +25,32 @@ list (
     list of ~{comment}~
     many, (items)
 )
+number 42
 """
 lexer = Lexer(source)
 
 print(*lexer, sep="\n")
 
 parser = Parser(source)
-print(parser.parse())
+tree = parser.parse()
+print(tree)
+
+
+class NumberSymbol(Symbol):
+    def __init__(self, number: int):
+        super().__init__(str(int))
+        self._number = number
+
+    def __repr__(self) -> str:
+        return f"NumberSymbol({self._number})"
+
+
+def transform_symbol(symbol: Symbol) -> Union[NumberSymbol, Symbol]:
+    try:
+        return NumberSymbol(int(str(symbol)))
+    except ValueError:
+        return symbol
+
+
+trans = transformer(transform_symbol=transform_symbol)
+print(trans(tree))

--- a/src/pybeech/beech_types.py
+++ b/src/pybeech/beech_types.py
@@ -17,6 +17,9 @@ class Symbol:
     def __hash__(self) -> int:
         return hash(self._value)
 
+    def __getitem__(self, item) -> Symbol:
+        return Symbol(self._value[item])
+
 
 Key = typing.Union[str, Symbol]
 Value = typing.Union[Key, 'Tree', 'List']

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -1,0 +1,1 @@
+"""Module for transforming a general Beech AST into a specified one."""

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -1,1 +1,46 @@
 """Module for transforming a general Beech AST into a specified one."""
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+from .beech_types import Symbol, Key, Value
+
+T = TypeVar("T")
+U = TypeVar("U")
+Transform = Callable[[T], T]
+
+
+def transformer(transform_symbol: Transform[Symbol] | None = None,
+                transform_string: Transform[str] | None = None) -> Transform[Value]:
+    """Return a transformation function for Beech values based on transformation rules for keys.
+
+    :param transform_symbol: rule for transforming symbols into other symbols
+    :param transform_string: rule for transforming strings into other strings
+
+    :return: inferred transformation rule for any Beech value
+    """
+    def _identity(_x: T) -> T: return _x
+    if transform_symbol is None:
+        transform_symbol = _identity
+    if transform_string is None:
+        transform_string = _identity
+
+    def transform_key(key: Key) -> Key:
+        if isinstance(key, Symbol):
+            return transform_symbol(key)
+        if isinstance(key, str):
+            return transform_string(key)
+        raise TypeError(f"Unexpected key type: {type(key)}")
+
+    def transform_value(value: Value) -> Value:
+        if isinstance(value, Symbol):
+            return transform_symbol(value)
+        if isinstance(value, str):
+            return transform_string(value)
+        if isinstance(value, dict):
+            return {transform_key(k): transform_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [transform_value(v) for v in value]
+        raise TypeError(f"Unexpected value type: {type(value)}")
+
+    return transform_value

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -5,8 +5,8 @@ from typing import Callable, TypeVar
 
 from .beech_types import Symbol, Key, Value
 
+
 T = TypeVar("T")
-U = TypeVar("U")
 Transform = Callable[[T], T]
 
 

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -20,6 +20,7 @@ def transformer(transform_symbol: Transform[Symbol] | None = None,
     :return: inferred transformation rule for any Beech value
     """
     def _identity(_x: T) -> T: return _x
+
     if transform_symbol is None:
         transform_symbol = _identity
     if transform_string is None:

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -27,6 +27,7 @@ def transformer(transform_symbol: Transform[Symbol] | None = None,
         transform_string = _identity
 
     def transform_key(key: Key) -> Key:
+        # Transform a Beech key (symbol or string).
         if isinstance(key, Symbol):
             return transform_symbol(key)
         if isinstance(key, str):
@@ -34,6 +35,7 @@ def transformer(transform_symbol: Transform[Symbol] | None = None,
         raise TypeError(f"Unexpected key type: {type(key)}")
 
     def transform_value(value: Value) -> Value:
+        # Transform a Beech value based on the rules provided.
         if isinstance(value, Symbol):
             return transform_symbol(value)
         if isinstance(value, str):

--- a/src/pybeech/transformer.py
+++ b/src/pybeech/transformer.py
@@ -14,8 +14,8 @@ def transformer(transform_symbol: Transform[Symbol] | None = None,
                 transform_string: Transform[str] | None = None) -> Transform[Value]:
     """Return a transformation function for Beech values based on transformation rules for keys.
 
-    :param transform_symbol: rule for transforming symbols into other symbols
-    :param transform_string: rule for transforming strings into other strings
+    :param transform_symbol: (optional) rule for transforming symbols into other symbols
+    :param transform_string: (optional) rule for transforming strings into other strings
 
     :return: inferred transformation rule for any Beech value
     """


### PR DESCRIPTION
This module allows users to transform Beech values. The rules for all Beech values are inferred from rules for transforming the two terminal value types (symbols and strings). This is to allow for special symbol forms, such as numbers and dates.

The module also defines the `Transform[T]` generic type, which is a function mapping some type `T` onto itself.