### PR TITLE
Default mode

### DIFF
--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -2,6 +2,7 @@
 from typing import Union
 
 from src.pybeech.beech_types import Symbol
+from src.pybeech.default_mode.symbol_parser import parse_symbol
 from src.pybeech.lexer import Lexer
 from src.pybeech.parser import Parser
 from src.pybeech.transformer import transformer
@@ -36,21 +37,21 @@ tree = parser.parse()
 print(tree)
 
 
-class NumberSymbol(Symbol):
-    def __init__(self, number: int):
-        super().__init__(str(int))
-        self._number = number
+# class NumberSymbol(Symbol):
+#     def __init__(self, number: int):
+#         super().__init__(str(int))
+#         self._number = number
+#
+#     def __repr__(self) -> str:
+#         return f"NumberSymbol({self._number})"
+#
+#
+# def transform_symbol(symbol: Symbol) -> Union[NumberSymbol, Symbol]:
+#     try:
+#         return NumberSymbol(int(str(symbol)))
+#     except ValueError:
+#         return symbol
+#
 
-    def __repr__(self) -> str:
-        return f"NumberSymbol({self._number})"
-
-
-def transform_symbol(symbol: Symbol) -> Union[NumberSymbol, Symbol]:
-    try:
-        return NumberSymbol(int(str(symbol)))
-    except ValueError:
-        return symbol
-
-
-trans = transformer(transform_symbol=transform_symbol)
+trans = transformer(transform_symbol=parse_symbol)
 print(trans(tree))

--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -2,7 +2,7 @@
 from typing import Union
 
 from src.pybeech.beech_types import Symbol
-from src.pybeech.default_mode.extension_types import Date
+from src.pybeech.default_mode.extension_types import Date, Time, DateTime
 from src.pybeech.default_mode.symbol_parser import parse_symbol
 from src.pybeech.lexer import Lexer
 from src.pybeech.parser import Parser
@@ -30,6 +30,8 @@ list (
 number 42
 date 2023-08-10
 "not a date" abc2023-08-10efg
+timestamp 2023-11-08T05:01:00+01:00
+utc 2038-01-19T03:14:07Z
 """
 lexer = Lexer(source)
 
@@ -60,4 +62,6 @@ trans = transformer(transform_symbol=parse_symbol)
 print(trans(tree))
 
 date = Date(2023, 8, 10)
-print(date, repr(date))
+time = Time(0, 4, 34, 1, 0)
+dt = DateTime(date, time)
+print(dt, repr(dt))

--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -2,6 +2,7 @@
 from typing import Union
 
 from src.pybeech.beech_types import Symbol
+from src.pybeech.default_mode.extension_types import Date
 from src.pybeech.default_mode.symbol_parser import parse_symbol
 from src.pybeech.lexer import Lexer
 from src.pybeech.parser import Parser
@@ -57,3 +58,6 @@ print(tree)
 
 trans = transformer(transform_symbol=parse_symbol)
 print(trans(tree))
+
+date = Date(2023, 8, 10)
+print(date, repr(date))

--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -28,6 +28,7 @@ list (
 )
 number 42
 date 2023-08-10
+"not a date" abc2023-08-10efg
 """
 lexer = Lexer(source)
 

--- a/src/pybeech/__main__.py
+++ b/src/pybeech/__main__.py
@@ -27,6 +27,7 @@ list (
     many, (items)
 )
 number 42
+date 2023-08-10
 """
 lexer = Lexer(source)
 

--- a/src/pybeech/beech_types.py
+++ b/src/pybeech/beech_types.py
@@ -9,10 +9,12 @@ class Symbol:
         self._value = value
 
     def __repr__(self) -> str:
-        return f"Symbol('{self._value}')"
+        # Use value's own `repr` method to reduce assumptions.
+        return f"{type(self).__name__}({repr(self._value)})"
 
     def __str__(self) -> str:
-        return self._value
+        # Wrap in an extra call to `str` in case a subclass changes the value type
+        return str(self._value)
 
     def __hash__(self) -> int:
         return hash(self._value)

--- a/src/pybeech/default_mode/extension_types.py
+++ b/src/pybeech/default_mode/extension_types.py
@@ -1,0 +1,16 @@
+"""Extension types defined for default mode."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Date:
+    year: int
+    month: int
+    day: int
+
+    def __str__(self) -> str:
+        return f"{self.year}-{self.month:02}-{self.day:02}"
+
+    def __hash__(self) -> int:
+        return hash(str(self))

--- a/src/pybeech/default_mode/extension_types.py
+++ b/src/pybeech/default_mode/extension_types.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 class StrHashMixin:
     """Mixin for a class whose hash is just that of its string value."""
+
     def __hash__(self) -> int:
         return hash(str(self))
 

--- a/src/pybeech/default_mode/extension_types.py
+++ b/src/pybeech/default_mode/extension_types.py
@@ -1,10 +1,17 @@
 """Extension types defined for default mode."""
+from __future__ import annotations
 
 from dataclasses import dataclass
 
 
+class StrHashMixin:
+    """Mixin for a class whose hash is just that of its string value."""
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+
 @dataclass
-class Date:
+class Date(StrHashMixin):
     """ISO 8601 date."""
 
     year: int
@@ -14,5 +21,30 @@ class Date:
     def __str__(self) -> str:
         return f"{self.year:04}-{self.month:02}-{self.day:02}"
 
-    def __hash__(self) -> int:
-        return hash(str(self))
+
+@dataclass
+class Time(StrHashMixin):
+    """ISO 8601 time."""
+
+    hour: int
+    minute: int
+    second: int
+    tz_hour: int | None = None
+    tz_minute: int | None = None  # Note: this is only used if `tz_hour` is not None.
+
+    def __str__(self) -> str:
+        simple_time = f"{self.hour:02}:{self.minute:02}:{self.second:02}"
+        tz_offset = (f"{self.tz_hour:+03}{f':{self.tz_minute:02}' if self.tz_minute is not None else ''}"
+                     if self.tz_hour is not None else "")
+        return f"{simple_time}{tz_offset}"
+
+
+@dataclass
+class DateTime(StrHashMixin):
+    """ISO 8601 date and time."""
+
+    date: Date
+    time: Time
+
+    def __str__(self) -> str:
+        return f"{self.date}T{self.time}"

--- a/src/pybeech/default_mode/extension_types.py
+++ b/src/pybeech/default_mode/extension_types.py
@@ -12,7 +12,7 @@ class Date:
     day: int
 
     def __str__(self) -> str:
-        return f"{self.year}-{self.month:02}-{self.day:02}"
+        return f"{self.year:04}-{self.month:02}-{self.day:02}"
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/src/pybeech/default_mode/extension_types.py
+++ b/src/pybeech/default_mode/extension_types.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 @dataclass
 class Date:
+    """ISO 8601 date."""
+
     year: int
     month: int
     day: int

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -50,7 +50,7 @@ class DateSymbol(Symbol):
     def try_parse(cls, value: str) -> DateSymbol | None:
         """Try to parse the value as an ISO 8601 date, or return None if failed."""
         date_match = re.match(
-            r"(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[12][0-9]|3[01])",
+            r"^(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[12][0-9]|3[01])$",
             value)
         if date_match is None:
             return None

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -1,6 +1,8 @@
 """Module containing the default symbol transformations."""
 from __future__ import annotations
 
+import re
+
 from src.pybeech.beech_types import Symbol
 
 
@@ -31,9 +33,28 @@ class NumberSymbol(Symbol):
 class DateSymbol(Symbol):
     """Symbol representing a date in the ISO 8601 format."""
 
+    def __init__(self, year: int, month: int, day: int):
+        super().__init__("")
+
+        from dataclasses import dataclass
+
+        @dataclass
+        class Date:
+            year: int
+            month: int
+            day: int
+
+        self._value = Date(year, month, day)
+
     @classmethod
     def try_parse(cls, value: str) -> DateSymbol | None:
         """Try to parse the value as an ISO 8601 date, or return None if failed."""
+        date_match = re.match(
+            r"(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[12][0-9]|3[01])",
+            value)
+        if date_match is None:
+            return None
+        return cls(**{k: int(v) for k, v in date_match.groupdict().items()})
 
 
 EXTENDED_SYMBOLS = [

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -1,20 +1,14 @@
 """Module containing the default symbol transformations."""
-import enum
+from __future__ import annotations
 
 from src.pybeech.beech_types import Symbol
-
-
-class SymbolType(enum.Enum):
-    NUMBER = "number"
-    DATE = "date-iso8601"
-    TEXT = "text"
 
 
 class TextSymbol(Symbol):
     """Symbol which is purely textual."""
 
     @classmethod
-    def from_base_symbol(cls, symbol: Symbol) -> 'TextSymbol':
+    def from_base_symbol(cls, symbol: Symbol) -> TextSymbol:
         return cls(str(symbol))
 
 
@@ -25,22 +19,33 @@ class NumberSymbol(Symbol):
         super().__init__("")  # Dummy value
         self._value = value
 
+    @classmethod
+    def try_parse(cls, value: str) -> NumberSymbol | None:
+        """Try to parse the value as a number, or return None if failed."""
+        try:
+            return cls(int(value, base=0))
+        except ValueError:
+            return None
+
 
 class DateSymbol(Symbol):
     """Symbol representing a date in the ISO 8601 format."""
 
+    @classmethod
+    def try_parse(cls, value: str) -> DateSymbol | None:
+        """Try to parse the value as an ISO 8601 date, or return None if failed."""
 
-class Parser:
+
+EXTENDED_SYMBOLS = [
+    NumberSymbol,
+    DateSymbol,
+]
+
+
+def parse_symbol(symbol: Symbol) -> Symbol:
     """Parse a symbol into its corresponding default mode subtype."""
-
-    def __init__(self, symbol: Symbol) -> None:
-        self._symbol = symbol
-        self._options: set[SymbolType] = {t for t in SymbolType}
-        self._index = 0
-
-    def parse(self) -> Symbol:
-        assert len(self._options) > 0
-        while len(self._options) > 1:
-            pass
-        assert self._options == {SymbolType.TEXT}
-        return TextSymbol(str(self._symbol))
+    value = str(symbol)
+    for cls in EXTENDED_SYMBOLS:
+        if (sym := cls.try_parse(value)) is not None:
+            return sym
+    return TextSymbol(value)

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import re
 
 from src.pybeech.beech_types import Symbol
+from .extension_types import Date
 
 
 class TextSymbol(Symbol):
@@ -35,15 +36,6 @@ class DateSymbol(Symbol):
 
     def __init__(self, year: int, month: int, day: int):
         super().__init__("")
-
-        from dataclasses import dataclass
-
-        @dataclass
-        class Date:
-            year: int
-            month: int
-            day: int
-
         self._value = Date(year, month, day)
 
     @classmethod

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 
 from src.pybeech.beech_types import Symbol
-from .extension_types import Date
+from .extension_types import Date, Time, DateTime
 
 
 class TextSymbol(Symbol):
@@ -48,10 +48,68 @@ class DateSymbol(Symbol):
             return None
         return cls(**{k: int(v) for k, v in date_match.groupdict().items()})
 
+    @property
+    def value(self):
+        return self._value
+
+
+class TimeSymbol(Symbol):
+    """Symbol representing a time in the ISO 8601 format."""
+
+    def __init__(self, hour: int, minute: int, second: int, tz_hour: int | None = None, tz_minute: int | None = None) -> None:
+        super().__init__("")
+        self._value = Time(hour, minute, second, tz_hour, tz_minute)
+
+    @classmethod
+    def try_parse(cls, value: str) -> TimeSymbol | None:
+        """Try to parse the value as an ISO 8601 time, or return None if failed."""
+        time_match = re.match(
+            r"^T?(?P<hour>[01][0-9]|2[0-4]):(?P<minute>[0-5][0-9]):(?P<second>[0-5][0-9]|60)"
+            r"(?P<timezone>Z|[-+\u2212](?:[01][0-9]|2[0-4]):?[0-5][0-9])?$",
+            value
+        )
+        if time_match is None:
+            return None
+        time_dict = time_match.groupdict()
+        timezone = time_dict.pop("timezone")
+        if timezone is not None:
+            hour, minute = "0", "0"
+            if timezone != "Z":
+                # tz_offset = timezone.replace("\u2212", "-").replace(":", "")
+                hour, minute = re.match(r"([+-]?\d{2}):?(\d{2})", timezone).groups()
+            time_dict["tz_hour"] = hour
+            time_dict["tz_minute"] = minute
+        return cls(**{k: int(v) for k, v in time_dict.items()})
+
+    @property
+    def value(self):
+        return self._value
+
+
+class DateTimeSymbol(Symbol):
+    """Symbol representing a date and time in the ISO 8601 format."""
+
+    def __init__(self, date: Date, time: Time):
+        super().__init__("")
+        self._value = DateTime(date, time)
+
+    @classmethod
+    def try_parse(cls, value: str):
+        date_part, t, time_part = value.partition("T")
+        if t == "":
+            return None
+        if (date := DateSymbol.try_parse(date_part)) is None:
+            return None
+        if (time := TimeSymbol.try_parse(t + time_part)) is None:
+            return None
+        return cls(date.value, time.value)
+
 
 EXTENDED_SYMBOLS = [
     NumberSymbol,
     DateSymbol,
+    TimeSymbol,
+    DateTimeSymbol,
 ]
 
 

--- a/src/pybeech/default_mode/symbol_parser.py
+++ b/src/pybeech/default_mode/symbol_parser.py
@@ -1,0 +1,46 @@
+"""Module containing the default symbol transformations."""
+import enum
+
+from src.pybeech.beech_types import Symbol
+
+
+class SymbolType(enum.Enum):
+    NUMBER = "number"
+    DATE = "date-iso8601"
+    TEXT = "text"
+
+
+class TextSymbol(Symbol):
+    """Symbol which is purely textual."""
+
+    @classmethod
+    def from_base_symbol(cls, symbol: Symbol) -> 'TextSymbol':
+        return cls(str(symbol))
+
+
+class NumberSymbol(Symbol):
+    """Symbol representing a number."""
+
+    def __init__(self, value: int) -> None:
+        super().__init__("")  # Dummy value
+        self._value = value
+
+
+class DateSymbol(Symbol):
+    """Symbol representing a date in the ISO 8601 format."""
+
+
+class Parser:
+    """Parse a symbol into its corresponding default mode subtype."""
+
+    def __init__(self, symbol: Symbol) -> None:
+        self._symbol = symbol
+        self._options: set[SymbolType] = {t for t in SymbolType}
+        self._index = 0
+
+    def parse(self) -> Symbol:
+        assert len(self._options) > 0
+        while len(self._options) > 1:
+            pass
+        assert self._options == {SymbolType.TEXT}
+        return TextSymbol(str(self._symbol))


### PR DESCRIPTION
Default mode adds some extra parsing capability to Beech. Currently, integers and ISO 8601 dates/times are supported as a special type of symbol, as well as `TextSymbol` for all other symbols.