### PR TITLE
Save comments in tokens

### DIFF
--- a/src/pybeech/lexer.py
+++ b/src/pybeech/lexer.py
@@ -129,7 +129,8 @@ class Lexer:
             self._consume_comments()
 
     def _is_reserved(self) -> bool:
-        return self._check("~{") or self._peek() in "'\"{}()#"
+        # Note: the check for "}" includes a closing "}~"
+        return self._check_any("~{", "'", '"', "{", "}", "(", ")", "#")
 
     def _is_symbolic(self) -> bool:
         if self._is_at_end():


### PR DESCRIPTION
Allows comments to be preserved by the lexer by attaching them to the token that follows them. All comments that come before a token are attached to it. Currently, comments are still ignored by the parser.