### PR TITLE
Fix false positive whitespace

### DIFF
--- a/src/pybeech/lexer.py
+++ b/src/pybeech/lexer.py
@@ -201,7 +201,7 @@ class Lexer:
             elif self._match("\n"):
                 # Multiline string.
                 out_string += self._source[start_index:self._index]
-                self._consume_whitespace()
+                self._consume_whitespace(report=False)
                 if self._match_any("'", '"'):
                     opener = self._previous()
                     start_index = self._index

--- a/src/pybeech/lexer.py
+++ b/src/pybeech/lexer.py
@@ -122,9 +122,11 @@ class Lexer:
                 break
         self._preceding_comments.append(self._source[start:self._index])
 
-    def _consume_whitespace(self) -> None:
-        while self._peek().isspace():
+    def _consume_whitespace(self, report: bool = True) -> None:
+        if report and self._peek().isspace():
             self._has_whitespace_before = True
+
+        while self._peek().isspace():
             self._advance()
             self._consume_comments()
 


### PR DESCRIPTION
Since the `_string` method calls to `_consume_whitespace` to ignore leading spaces inside a string literal, a multiline string could incorrectly set `_has_whitespace_before`, allowing it to omit the required space before the whole literal.

The fix is to pass a flag to `_consume_whitespace` to tell it whether or not any spaces consumed should be reported.

Note: this also gives a good excuse to move the setting of the `_has_whitespace_before` flag out of the loop.